### PR TITLE
Use node's built-in crypto module for randomBytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
       "email": "dev@tavan.de"
     }
   ],
-  "dependencies": {
-    "crypto-js": "^3.1.6"
-  },
   "description": "Rigorous implementation of RFC4122 (v1 and v4) UUIDs for React Native",
   "devDependencies": {
     "nyc": "^2.2.0"

--- a/uuid.js
+++ b/uuid.js
@@ -56,7 +56,7 @@
     // Moderately fast, high quality
     if ('function' === typeof require) {
       try {
-        var _rb = require('crypto-js').randomBytes;
+        var _rb = require('crypto').randomBytes;
         _nodeRNG = _rng = _rb && function() {return _rb(16);};
         _rng();
       } catch(e) {}


### PR DESCRIPTION
In the node environment, such as when running tests, the error `_rng is not a function` would occur.

This is because we were attempting to use the `randomBytes` function from the [crypto-js](https://github.com/brix/crypto-js) library.  However, that library doesn’t have such a function, and as far as I can tell, it never has.

Node.js has a built-in `crypto` module that does provide a `randomBytes` function, and [has since Node v0.5.8](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback).

This PR removes the dependency on the `crypto-js` library and modifies the code to use `crypto` instead.

Fixes #2