### PR TITLE
Better solution for _rng is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
       "email": "dev@tavan.de"
     }
   ],
+  "dependencies": {
+    "randombytes": "^2.0.3"
+  },
   "description": "Rigorous implementation of RFC4122 (v1 and v4) UUIDs for React Native",
   "devDependencies": {
     "nyc": "^2.2.0"

--- a/uuid.js
+++ b/uuid.js
@@ -56,7 +56,7 @@
     // Moderately fast, high quality
     if ('function' === typeof require) {
       try {
-        var _rb = require('crypto').randomBytes;
+        var _rb = require('randombytes');
         _nodeRNG = _rng = _rb && function() {return _rb(16);};
         _rng();
       } catch(e) {}


### PR DESCRIPTION
This fixes the breakage we caused in #3.  Sorry for the oversight.

The react-native packager seems to pull in any required package, including those that are only dynamically required in certain cases.  Thus, it was trying to bring in node’s `crypto` library and failing.

This PR instead uses the [randombytes](https://www.npmjs.com/package/randombytes) module, which will use node’s crypto module under the hood, but also provides a browser implementation.  This solves the `require` issue and works in both the react-native and mocha test environments.

I think it would be possible to use this library in the browser environment as well, instead of the extra work done in `setupBrowser()`.  However, I’m not sure how best to test that and make sure it works, so I haven’t done it.