### PR TITLE
Bug fix: Unable to resolve module `buffer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     }
   ],
   "dependencies": {
-    "randombytes": "^2.0.3"
+    "randombytes": "^2.0.3",
+    "buffer": "^5.2.1"
   },
   "description": "Rigorous implementation of RFC4122 (v1 and v4) UUIDs for React Native",
   "devDependencies": {


### PR DESCRIPTION
Fixed Issue https://github.com/eugenehp/react-native-uuid/issues/9

error: bundling failed: Error: Unable to resolve module buffer from node_modules/safe-buffer/index.js: Module buffer does not exist in the Haste module map