### PR TITLE
feat: export `uuid` as a named export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub issue and pull request templates
 - prettier:check script for CI/CD validation
 - Enhanced TypeScript compiler options for stricter type checking
+- Added `uuid` named export so you can auto-import this library
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ npm install react-native-uuid
 
 ```javascript
 import uuid from 'react-native-uuid';
+// Or: import { uuid } from 'react-native-uuid';
+
 uuid.v4(); // ⇨ '11edc52b-2918-4d71-9058-f7285e29d894'
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {v5} from './v5';
 
 import {NIL, DNS, URL, OID, X500} from './utils';
 
-export default {
+export const uuid = {
   parse,
   unparse,
   validate,
@@ -27,3 +27,5 @@ export default {
   OID,
   X500,
 };
+
+export default uuid;


### PR DESCRIPTION
## Description

This PR adds a named export called `uuid`

## Motivation and Context

In VS code if you type `uuid` in a new file, VS code wouldn't suggest importing `react-native-uuid` because it has no way of knowing you're referring to it, since the import name can be anything.

With a named export, VS code can find `uuid` in the library and therefore suggest importing it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor / Code improvement
- [ ] Dependency update

## Testing

- [ ] Tests pass locally with my changes
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] All test suites are passing

## Code Quality

- [ ] Code follows project style guidelines
- [ ] Code is formatted with Prettier
- [ ] No linting errors
- [ ] TypeScript strict mode compliant
- [ ] Added/updated relevant JSDoc comments

## Testing Instructions

- None

## Screenshots / Demo

- None

## Checklist Before Merge

- [x] PR title follows conventional commits (feat:, fix:, etc.)
- [x] CHANGELOG.md is updated (if user-facing change)
- [x] README.md is updated (if needed)
- [x] All CI checks pass
- [x] Code review approved

## Breaking Changes

- None

## Notes

- None
